### PR TITLE
Adds better naming for plugin instances

### DIFF
--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -1,11 +1,11 @@
 # Please make sure to update the license_key information with the license key for your New Relic
 # account.
 #
-# This configuration file holds examples for all plugins. You only need to uncomment 
+# This configuration file holds examples for all plugins. You only need to uncomment
 # the lines for the product you are using.
 #
 # Example configuration is shown below. Uncomment (remove #) the needed lines for
-# your environment. 
+# your environment.
 #
 #
 newrelic:
@@ -22,10 +22,10 @@ newrelic:
 # Agent Configuration:
 #
 agents:
-# 
+#
 # NOTE: You must uncomment and configure the plugins you want to use. By default they are
 # all disabled.
-# 
+#
 # Configuration for RabbitMQ
   rabbitmq:
     # Must enable rabbit management plugin
@@ -61,6 +61,7 @@ agents:
   redis:
     # The - allows you to define multiple servers
     #-
+      #name: Production Store
       #hostname: localhost
       #hostport: 6379
       # Set "debug: true" to see metrics in stdout instead of sent to New Relic"
@@ -68,7 +69,8 @@ agents:
       # Set "testrun: true" to use input from local text/html files. Only parses input once, then quits.
       #testrun: false
     #-
-      #hostname: localhost
+      #name: Slave Store
+      #hostname: another.host.com
       #hostport: 6389
       # Set "debug: true" to see metrics in stdout instead of sent to New Relic"
       #debug: false

--- a/plugins/pivotal_redis_plugin/config/template_newrelic_plugin.yml
+++ b/plugins/pivotal_redis_plugin/config/template_newrelic_plugin.yml
@@ -18,7 +18,8 @@ newrelic:
 agents:
   redis:
       -
-        hostname: localhost 
+        name: redis-master
+        hostname: localhost
         hostport: 6379
         # Set "debug: true" to see metrics in stdout instead of sent to New Relic"
         debug: true
@@ -26,7 +27,8 @@ agents:
         testrun: false
 # Multiple Redit Servers may be defined
 #      -
-#        hostname: localhost 
+#        name: redis-slave
+#        hostname: another.host.com
 #        hostport: 6389
 #        # Set "debug: true" to see metrics in stdout instead of sent to New Relic"
 #        debug: true

--- a/plugins/pivotal_redis_plugin/pivotal_redis_plugin.rb
+++ b/plugins/pivotal_redis_plugin/pivotal_redis_plugin.rb
@@ -41,14 +41,19 @@ module RedisPlugin
   #
   class Agent < NewRelic::Plugin::Agent::Base
 
-    agent_config_options :hostname, :username, :password, :hostport, :agent_name, :debug, :testrun
+    agent_config_options :name, :hostname, :username, :password, :hostport, :agent_name, :debug, :testrun
     agent_guid "com.gopivotal.newrelic.plugins.redis"
     agent_version "1.0.4"
 
     # The block runs in the context of the agent instance.
     #
-    if :hostport then agent_human_labels("Redis") { "#{hostname}:#{hostport}" }
-    else agent_human_labels("Redis") { "#{hostname}:80" } end
+    if :name
+      agent_human_labels("Redis") { name }
+    elsif :hostport
+      agent_human_labels("Redis") { "#{hostname}:#{hostport}" }
+    else
+      agent_human_labels("Redis") { "#{hostname}:80" }
+    end
 
     def setup_metrics
       @metric_types = Hash.new("unit") # Default metric label
@@ -89,7 +94,7 @@ module RedisPlugin
       rescue => e
         $stderr.puts "[Redis] Exception while processing metrics. Check configuration."
         $stderr.puts e.message
-        if "#{self.debug}" == "true" 
+        if "#{self.debug}" == "true"
           $stderr.puts e.backtrace.inspect
         end
       end
@@ -126,10 +131,10 @@ module RedisPlugin
       end
     end
   end
-  
+
   NewRelic::Plugin::Setup.install_agent :redis, self
 
-  # Check if we're included as a module and if not we launch the agent, otherwise the 
+  # Check if we're included as a module and if not we launch the agent, otherwise the
   # main pivotal agent calls this with all the plugins installed
   #
   if __FILE__==$0


### PR DESCRIPTION
We should not be required to label redis instance monitoring strictly by using the hostname; in some cases only IPs are available and not altogether very telling. The same applies for **localhost**.

Instead, this change allows you to use a _name_ option via config, and it lends preference to that value over the previously existing ones.
