### PR TITLE
Let agent run as daemon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "http://rubygems.org"
 gem "newrelic_plugin"
 gem 'rabbitmq_manager', '~> 0.1.0'
 gem "redis"
-
+gem "daemons"

--- a/pivotal_agent.daemon
+++ b/pivotal_agent.daemon
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'daemons'
+require 'bundler/setup'
+
+Daemons.run(File.dirname(Pathname.new(__FILE__).realpath) + '/pivotal_agent')


### PR DESCRIPTION
provides a ruby wrapper around the `pivotal_agent` script to start
it as daemon.
Adds a dependency to the daemons gem.