### PR TITLE
Force redis client to disconnect

### DIFF
--- a/plugins/pivotal_redis_plugin/pivotal_redis_plugin.rb
+++ b/plugins/pivotal_redis_plugin/pivotal_redis_plugin.rb
@@ -89,6 +89,7 @@ module RedisPlugin
         redis = Redis.new(options)
         info = redis.info
         report_stats(info)
+        redis.client.disconnect
         # Only do testruns once, then quit
         if "#{self.testrun}" == "true" then exit end
       rescue => e


### PR DESCRIPTION
This ensures that connections are not leaked.
