### PR TITLE
Adding optional instance_name config for RabbitMQ.

### DIFF
--- a/plugins/pivotal_rabbitmq_plugin/pivotal_rabbitmq_plugin.rb
+++ b/plugins/pivotal_rabbitmq_plugin/pivotal_rabbitmq_plugin.rb
@@ -36,9 +36,14 @@ module NewRelic
       agent_guid 'com.pivotal.newrelic.plugin.rabbitmq'
       agent_version '1.0.5'
       agent_config_options :management_api_url
+      agent_config_options :instance_name
       agent_human_labels('RabbitMQ') do
-        uri = URI.parse(management_api_url)
-        "#{uri.host}:#{uri.port}"
+        if instance_name
+            instance_name
+        else
+          uri = URI.parse(management_api_url)
+          "#{uri.host}:#{uri.port}"
+        end
       end
 
       def poll_cycle


### PR DESCRIPTION
We would like to give human-readable names to our RabbitMQ instances.  This lets us add instance_name to the config file.  I didn't see any other way to change the name to be other than the IP address/port, and we can't use a domain name.  It defaults to the previous behavior if nothing is set.