### PR TITLE
Infinite loop fix.

### DIFF
--- a/plugins/pivotal_rabbitmq_plugin/pivotal_rabbitmq_plugin.rb
+++ b/plugins/pivotal_rabbitmq_plugin/pivotal_rabbitmq_plugin.rb
@@ -76,7 +76,7 @@ module NewRelic
         if "#{self.debug}" == "true"
           puts("#{metricname}[#{metrictype}] : #{metricvalue}")
         else
-          report_metric_check_debug metricname, metrictype, metricvalue
+          report_metric metricname, metrictype, metricvalue
         end
       end
       private


### PR DESCRIPTION
Looks like a global find all replace accidentally changed the method call from "report_metric" to "report_metric_check_debug".  This creates an infinite loop unless in debug mode.