### PR TITLE
Improved upstart script

### DIFF
--- a/extras/pivotal_agent-upstart.conf
+++ b/extras/pivotal_agent-upstart.conf
@@ -1,29 +1,9 @@
-#
-# This is provided as an example of a Ubuntu style upstart script
-# You'll want to give it a more useful name
-#
-# pivotal_agent - myservice job file
-
 description "Pivotal Monitoring Agent for New Relic"
 author "Pivotal - https://github.com/gopivotal/newrelic_pivotal_agent/"
-
-# Change this to the user running the agent
-env USER=sysadmin
-
-# When to start the service
 start on runlevel [2345]
-
-# When to stop the service
 stop on runlevel [016]
-
-# Automatically restart process if crashed
 respawn
-
-# Run before process
-pre-start script
-    [ -d /var/log/pivotal_agent ] || mkdir -p /var/log/pivotal_agent
-end script
-
-# This assumes that start-stop-daemon is present on the system
-# Change this to the path where pivotal_agent is located 
-exec start-stop-daemon --start --make-pidfile --pidfile /var/run/pivotal_agent.pid --chuid $USER --exec /opt/newrelic_pivotal_agent/pivotal_agent 
+setuid nobody
+setgid nogroup
+console log
+exec /opt/newrelic_pivotal_agent/pivotal_agent


### PR DESCRIPTION
Don't use start-stop-daemon, upstart takes care of PID tracking
Use upstart's built in logging
Run as nobody, no privileges are required
Remove superfluous comments