### PR TITLE
Allow setting RabbitMQ component name

### DIFF
--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -36,6 +36,9 @@ agents:
     # RabbitMQ Default URL versions prior to 3.0
     #management_api_url: http://guest:guest@localhost:55672
     #
+    # You can override the component name. If this is not used, the server host/port are used as the component name.
+    #component_name: 'Server A'
+    #
     # Set "debug: true" to see additional debug output
     # Note: This logs the metrics locally and does not send data to new relic.
     #debug: false

--- a/plugins/pivotal_rabbitmq_plugin/pivotal_rabbitmq_plugin.rb
+++ b/plugins/pivotal_rabbitmq_plugin/pivotal_rabbitmq_plugin.rb
@@ -35,10 +35,14 @@ module NewRelic
     class Agent < NewRelic::Plugin::Agent::Base
       agent_guid 'com.pivotal.newrelic.plugin.rabbitmq'
       agent_version '1.0.5'
-      agent_config_options :management_api_url, :debug
+      agent_config_options :management_api_url, :debug, :component_name
       agent_human_labels('RabbitMQ') do
-        uri = URI.parse(management_api_url)
-        "#{uri.host}:#{uri.port}"
+        if (!"#{self.component_name}".empty?)
+          "#{self.component_name}"
+        else
+          uri = URI.parse(management_api_url)
+          "#{uri.host}:#{uri.port}"
+        end
       end
 
       def poll_cycle


### PR DESCRIPTION
This isn't the nicest solution, but it's a quick solution to allow us to run different agents for different vhosts (we use different users that only have permission to that vhost).
Having all vhosts under the same component would list way too many queues.