### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ _Please refer back to this document as a checklist before issuing any pull reque
 ## Understanding the basics
 Not sure what a pull request is, or how to submit one?  Take a look at GitHub's excellent [help documentation][] first.
 
-[help documentation]: http://help.github.com/send-pull-requests
+[help documentation]: https://help.github.com/send-pull-requests
 
 ## Search GitHub Issues first; create an issue if necessary
 Is there already an issue that addresses your concern?  Do a bit of searching in our [GitHub issue tracker][] to see if you can find something similar. If not, please create a new issue before submitting a pull request unless the change is truly trivial, e.g. typo fixes, removing compiler warnings, etc.
@@ -79,7 +79,7 @@ then be sure to update it to 2014 appropriately
 ```
 
 ## Squash commits
-Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes. In addition to the man pages for git, there are many resources online to help you understand how these tools work. Here is one: <http://git-scm.com/book/en/Git-Tools-Rewriting-History>.
+Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes. In addition to the man pages for git, there are many resources online to help you understand how these tools work. Here is one: <https://git-scm.com/book/en/Git-Tools-Rewriting-History>.
 
 ## Use real name in git commits
 Please configure git to use your real first and last name for any commits you intend to submit as pull requests. For example, this is not acceptable:
@@ -144,7 +144,7 @@ Issue: #10, #11
 1. Mention associated GitHub issue(s) at the end of the commit comment, prefixed with "Issue: " as above
 1. In the body of the commit message, explain how things worked before this commit, what has changed, and how things work now
 
-[commit guidelines section of Pro Git]: http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
+[commit guidelines section of Pro Git]: https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project#Commit-Guidelines
 
 ## Run all tests prior to submission
 See the [Running Tests][] section of the README for instructions. Make sure that all tests pass prior to submitting your pull request.

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gem "newrelic_plugin"
 gem 'rabbitmq_manager', '~> 0.1.0'
 gem "redis"

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This procedure installs plugins that gather metrics about the following products
 * Ensure that Ruby (version 1.9.1 or later if using the RabbitMQ Plugin) is installed on the computer on which you will install the Pivotal Plugins for New Relic.  
 * Install the `bundle` Ruby gem.
 * Ensure that the computer on which you are installing the Pivotal plugins has network access to the computer on which the desired product to be monitored (such as RabbitMQ) is installed, or that both are installed on the same computer.
-* For RabbitMQ Monitoring: Enable the RabbitMQ management plugins by executing the `rabbitmq-plugins enable rabbitmq_management` command.  See [Management Plugins](http://www.rabbitmq.com/management.html).
-* For vFabric Web Server Monitoring: The vFabric Web Server monitoring module (mod_bmx) is enabled by default in a Web Server instance and allows access from `localhost`. If, however, the Web Server instance is on a remote machine, you will need to enable access. The default URL for BMX is http://localhost/bmx.  See [Configure BMX for Monitoring vFabric Web Server Instances](http://pubs.vmware.com/vfabric53/topic/com.vmware.vfabric.web-server.5.3/web-server/config-mod-bmx.html).
+* For RabbitMQ Monitoring: Enable the RabbitMQ management plugins by executing the `rabbitmq-plugins enable rabbitmq_management` command.  See [Management Plugins](https://www.rabbitmq.com/management.html).
+* For vFabric Web Server Monitoring: The vFabric Web Server monitoring module (mod_bmx) is enabled by default in a Web Server instance and allows access from `localhost`. If, however, the Web Server instance is on a remote machine, you will need to enable access. The default URL for BMX is http://localhost/bmx.  See [Configure BMX for Monitoring vFabric Web Server Instances](https://pubs.vmware.com/vfabric53/topic/com.vmware.vfabric.web-server.5.3/web-server/config-mod-bmx.html).
 
 ## Installation Procedure
 

--- a/config/template_newrelic_plugin.yml
+++ b/config/template_newrelic_plugin.yml
@@ -32,9 +32,9 @@ agents:
     # Note: When monitoring multiple nodes you should use the real hostnames instead of localhost
     # Uncomment the appropriate line for your version
     # RabbitMQ Default URL version 3.0
-    #management_api_url: http://guest:guest@localhost:15672
+    #management_api_url: https://guest:guest@localhost:15672
     # RabbitMQ Default URL versions prior to 3.0
-    #management_api_url: http://guest:guest@localhost:55672
+    #management_api_url: https://guest:guest@localhost:55672
     #
     # Set "debug: true" to see additional debug output
     # Note: This logs the metrics locally and does not send data to new relic.

--- a/plugins/pivotal_httpd_mod_bmx_plugin/Gemfile
+++ b/plugins/pivotal_httpd_mod_bmx_plugin/Gemfile
@@ -1,2 +1,2 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem "newrelic_plugin", :git => "git@github.com:newrelic-platform/newrelic_plugin.git", :branch => 'release'

--- a/plugins/pivotal_rabbitmq_plugin/Gemfile
+++ b/plugins/pivotal_rabbitmq_plugin/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gem "newrelic_plugin", :git => "git@github.com:newrelic-platform/newrelic_plugin.git", :branch => 'release'
 gem 'rabbitmq_manager', '~> 0.1.0'

--- a/plugins/pivotal_redis_plugin/Gemfile
+++ b/plugins/pivotal_redis_plugin/Gemfile
@@ -1,3 +1,3 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 gem "newrelic_plugin"
 gem "redis"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://guest:guest@localhost:15672 (UnknownHostException) with 1 occurrences migrated to:  
  https://guest:guest@localhost:15672 ([https](https://guest:guest@localhost:15672) result UnknownHostException).
* http://guest:guest@localhost:55672 (UnknownHostException) with 1 occurrences migrated to:  
  https://guest:guest@localhost:55672 ([https](https://guest:guest@localhost:55672) result UnknownHostException).
* http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://rubygems.org with 4 occurrences migrated to:  
  https://rubygems.org ([https](https://rubygems.org) result 200).
* http://www.rabbitmq.com/management.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/management.html ([https](https://www.rabbitmq.com/management.html) result 200).
* http://pubs.vmware.com/vfabric53/topic/com.vmware.vfabric.web-server.5.3/web-server/config-mod-bmx.html with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabric53/topic/com.vmware.vfabric.web-server.5.3/web-server/config-mod-bmx.html ([https](https://pubs.vmware.com/vfabric53/topic/com.vmware.vfabric.web-server.5.3/web-server/config-mod-bmx.html) result 301).
* http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project ([https](https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project) result 302).
* http://git-scm.com/book/en/Git-Tools-Rewriting-History with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Git-Tools-Rewriting-History ([https](https://git-scm.com/book/en/Git-Tools-Rewriting-History) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost/bmx with 1 occurrences